### PR TITLE
Examples of ChaosToolKit Bundle #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ export NODE_LABEL="beta.kubernetes.io/os=linux"
 
 chaos run chaos/node-delete.yaml
 
+chaos run chaos/node-drain.yaml
+
+chaos run chaos/node-uncordon.yaml
 
 
 # Destroying What We Created #

--- a/chaos/node-drain.yaml
+++ b/chaos/node-drain.yaml
@@ -1,5 +1,5 @@
 version: 1.0.0
-title: What happens if we delete a node
+title: What happens if we drain a node
 description: All the instances are distributed among healthy nodes and the applications are healthy
 tags:
 - k8s
@@ -17,20 +17,21 @@ steady-state-hypothesis:
     tolerance: true
     provider:
       type: python
-      func: all_pods_healthy
+      func: all_microservices_healthy
       module: chaosk8s.probes
       arguments:
         ns: sock-shop
 method:
 - type: action
-  name: delete-node
+  name: drain-node
   provider:
     type: python
-    func: delete_nodes
+    func: drain_nodes
     module: chaosk8s.node.actions
     arguments:
       label_selector: ${node_label}
       count: 1
       pod_namespace: front-end
+      delete_pods_with_local_storage: true
   pauses: 
-    after: 10
+    after: 1

--- a/chaos/node-uncordon.yaml
+++ b/chaos/node-uncordon.yaml
@@ -1,5 +1,5 @@
 version: 1.0.0
-title: What happens if we delete a node
+title: What happens if we drain a node
 description: All the instances are distributed among healthy nodes and the applications are healthy
 tags:
 - k8s
@@ -23,14 +23,24 @@ steady-state-hypothesis:
         ns: sock-shop
 method:
 - type: action
-  name: delete-node
+  name: drain-node
   provider:
     type: python
-    func: delete_nodes
+    func: drain_nodes
     module: chaosk8s.node.actions
     arguments:
       label_selector: ${node_label}
       count: 1
       pod_namespace: front-end
+      delete_pods_with_local_storage: true
   pauses: 
-    after: 10
+    after: 1
+rollbacks:
+- type: action
+  name: uncordon-node
+  provider:
+    type: python
+    func: uncordon_node
+    module: chaosk8s.node.actions
+    arguments:
+      label_selector: ${node_label}

--- a/k8s/hpa-app.yaml
+++ b/k8s/hpa-app.yaml
@@ -1,0 +1,22 @@
+---
+
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: front-end
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: front-end
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: 80
+  - type: Resource
+    resource:
+      name: memory
+      targetAverageUtilization: 80


### PR DESCRIPTION
- Completed README.md with commands and steps for de examples of ChaosToolKit (CTK) for node experiments.

- Added CTK files in /chaos folder for examples of drain and uncordon Node.

- File for Horizontal Pod Autoscaler(HPA) for Front-End pod in /k8s folder.