### PR TITLE
Examples of ChaosToolKit Bundle #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,35 @@ chaos run chaos/node-drain.yaml
 
 chaos run chaos/node-uncordon.yaml
 
+# Exploring Experiments Journal #
+#################################
+
+cat chaos/health-http.yaml
+
+chaos run chaos/health-http.yaml \
+--rollback-strategy=always \
+--journal-path journal-health-http.json
+
+cat journal-health-http.json
+
+##############################
+# Creating Experiment Report #
+##############################
+
+# Start a local Docker daemon
+
+docker container run \
+--user $(id -u) \
+--volume $PWD:/tmp/result \
+-it \
+chaostoolkit/reporting \
+-- report \
+--export-format=pdf \
+journal-health-http.json \
+report.pdf
+
+# If Windows, open the `report.pdf` file manually
+open report.pdf
 
 # Destroying What We Created #
 #############################################################

--- a/chaos/all-health-http.yml
+++ b/chaos/all-health-http.yml
@@ -1,0 +1,84 @@
+version: 1.0.0
+title: What happens if we terminate an instance of the application?
+description: If an instance of the application is terminated, a new instance should be created
+tags:
+  - k8s
+  - pod
+  - deployment
+configuration:
+  ingress_host:
+    type: env
+    key: INGRESS_HOST
+steady-state-hypothesis:
+  title: The app is healthy
+  probes:
+    - name: The app responds to requests
+      type: probe
+      tolerance: 200
+      provider:
+        type: http
+        timeout: 3
+        verify_tls: false
+        url: http://${ingress_host}
+        headers:
+          Host: sock-shop.acme.com
+method:
+  - type: action
+    name: terminate-app-pod
+    provider:
+      type: python
+      module: chaosk8s.pod.actions
+      func: terminate_pods
+      arguments:
+        label_selector: name=front-end
+        rand: false
+        ns: sock-shop
+    pauses:
+      after: 50
+steady-state-hypothesis:
+  title: The app is healthy
+  probes:
+    - type: probe
+      name: app-responds-to-requests
+      tolerance: 200
+      provider:
+        type: http
+        timeout: 10
+        verify_tls: false
+        url: http://${ingress_host}
+    - type: probe
+      tolerance: 200
+      ref: app-responds-to-requests
+    - type: probe
+      tolerance: 200
+      ref: app-responds-to-requests
+    - type: probe
+      tolerance: 200
+      ref: app-responds-to-requests
+    - type: probe
+      tolerance: 200
+      ref: app-responds-to-requests
+method:
+  - type: action
+    name: abort-failure
+    provider:
+      type: process
+      path: kubectl
+      arguments:
+        - run
+        - siege
+        - --namespace
+        - sock-shop
+        - --image
+        - yokogawa/siege
+        - -it
+        - --rm
+        - --
+        - --concurrent
+        - 50
+        - --time
+        - 20S
+        - "http://a41f026bd7bfa4347a1723ce3103676d-1946661046.us-west-2.elb.amazonaws.com"
+    pauses:
+      after: 5
+

--- a/chaos/all.yaml
+++ b/chaos/all.yaml
@@ -1,0 +1,126 @@
+version: 1.0.0
+title: What happens if we terminate an instance of the application?
+description: If an instance of the application is terminated, a new instance should be created
+tags:
+- k8s
+- pod
+- deployment
+configuration:
+  ingress_host:
+      type: env
+      key: INGRESS_HOST
+steady-state-hypothesis:
+  title: The app is healthy
+  probes:
+  - name: The app responds to requests
+    type: probe
+    tolerance: 200
+    provider:
+      type: http
+      timeout: 3
+      verify_tls: false
+      url: http://${ingress_host}/demo/person
+      headers:
+        Host: sock-shop.acme.com
+method:
+- type: action
+  name: terminate-app-pod
+  provider:
+    type: python
+    module: chaosk8s.pod.actions
+    func: terminate_pods
+    arguments:
+      label_selector: name=front-end
+      rand: true
+      ns: sock-shop
+  pauses: 
+    after: 2
+steady-state-hypothesis:
+  title: The app is healthy
+  probes:
+  - type: probe
+    name: app-responds-to-requests
+    tolerance: 200
+    provider:
+      type: http
+      timeout: 10
+      verify_tls: false
+      url: http://${ingress_host}?addr=http://sock-shop
+      headers:
+        Host: repeater.acme.com
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+method:
+- type: action
+  name: abort-failure
+  provider:
+    type: python
+    module: chaosistio.fault.actions
+    func: add_abort_fault
+    arguments:
+      virtual_service_name: sock-shop
+      http_status: 500
+      routes:
+        - destination:
+            host: sock-shop
+            subset: primary
+      percent: 50
+      version: networking.istio.io/v1alpha3
+      ns: sock-shop
+- type: action
+  name: delay
+  provider:
+    type: python
+    module: chaosistio.fault.actions
+    func: add_delay_fault
+    arguments:
+      virtual_service_name: sock-shop
+      fixed_delay: 15s
+      routes:
+        - destination:
+            host: sock-shop
+            subset: primary
+      percent: 50
+      version: networking.istio.io/v1alpha3
+      ns: sock-shop
+  pauses: 
+    after: 1
+rollbacks:
+- type: action
+  name: remove-abort-failure
+  provider:
+    type: python
+    func: remove_abort_fault
+    module: chaosistio.fault.actions
+    arguments:
+      virtual_service_name: sock-shop
+      routes:
+        - destination:
+            host: sock-shop
+            subset: primary
+      version: networking.istio.io/v1alpha3
+      ns: sock-shop
+- type: action
+  name: remove-delay
+  provider:
+    type: python
+    func: remove_delay_fault
+    module: chaosistio.fault.actions
+    arguments:
+      virtual_service_name: sock-shop
+      routes:
+        - destination:
+            host: sock-shop
+            subset: primary
+      version: networking.istio.io/v1alpha3
+      ns: sock-shop

--- a/chaos/health-db.yaml
+++ b/chaos/health-db.yaml
@@ -1,0 +1,37 @@
+version: 1.0.0
+title: What happens if we terminate an instance of the DB?
+description: If an instance of the DB is terminated, dependant applications should still be operational.
+tags:
+- k8s
+- pod
+- http
+configuration:
+  ingress_host:
+      type: env
+      key: INGRESS_HOST
+steady-state-hypothesis:
+  title: The app is healthy
+  probes:
+  - name: app-responds-to-requests
+    type: probe
+    tolerance: 200
+    provider:
+      type: http
+      timeout: 3
+      verify_tls: false
+      url: http://${ingress_host}/demo/person
+      headers:
+        Host: sock-shop.acme.com
+method:
+- type: action
+  name: terminate-db-pod
+  provider:
+    type: python
+    module: chaosk8s.pod.actions
+    func: terminate_pods
+    arguments:
+      label_selector: name=carts-db
+      rand: true
+      ns: sock-shop
+  pauses: 
+    after: 2

--- a/chaos/health-http.yaml
+++ b/chaos/health-http.yaml
@@ -1,0 +1,49 @@
+version: 1.0.0
+title: What happens if we terminate an pod of the application?
+description: If an pod of the application is terminated, the applications as a whole should still be operational.
+tags:
+- k8s
+- pod
+- http
+configuration:
+  ingress_host:
+      type: env
+      key: INGRESS_HOST
+steady-state-hypothesis:
+  title: The app is healthy
+  probes:
+  - name: app-responds-to-requests
+    type: probe
+    tolerance: 200
+    provider:
+      type: http
+      timeout: 3
+      verify_tls: false
+      url: http://${ingress_host}
+      headers:
+        Host: sock-shop.acme.com
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+method:
+- type: action
+  name: terminate-app-pod
+  provider:
+    type: python
+    module: chaosk8s.pod.actions
+    func: terminate_pods
+    arguments:
+      label_selector: name=front-end
+      rand: false
+      ns: sock-shop
+  pauses: 
+    after: 1

--- a/chaos/health-pause.yaml
+++ b/chaos/health-pause.yaml
@@ -13,7 +13,7 @@ steady-state-hypothesis:
     tolerance: true
     provider:
       type: python
-      func: all_pods_healthy
+      func: all_microservices_healthy
       module: chaosk8s.probes
       arguments:
         ns: sock-shop
@@ -28,3 +28,5 @@ method:
       label_selector: name=front-end
       rand: true
       ns: sock-shop
+  pauses: 
+    after: 10

--- a/chaos/jmeter-frontend-cronjob.yaml
+++ b/chaos/jmeter-frontend-cronjob.yaml
@@ -1,0 +1,66 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: jmeter-frontend-cronjob
+  namespace: sock-shop
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            name: jmeter-fronted-cronjob
+        spec:
+          serviceAccountName: chaos-eng-svc-acct-s3
+          restartPolicy: Never
+
+          volumes:
+            - name: chaos-eng-config
+              emptyDir: {}
+
+          containers:
+            - name: s3-uploader
+              image: amazon/aws-cli:latest
+              command: [
+                'bash',
+                '-c',
+                'aws s3api put-object --bucket chaos-engineering-config-files --key csv/$(date "+%Y%m%d-%H%M%s")-frontend.csv --body /config_data/summary.csv'
+              ]
+              volumeMounts:
+                - name: chaos-eng-config
+                  mountPath: "/config_data"
+
+          initContainers:
+            - name: s3-downloader
+              image: amazon/aws-cli:latest
+              args: [
+                "s3api",
+                "get-object",
+                "--bucket",
+                "chaos-engineering-config-files",
+                "--key",
+                "FrontEnd.jmx",
+                "/config_data/FrontEnd.jmx"
+              ]
+              volumeMounts:
+                - name: chaos-eng-config
+                  mountPath: "/config_data"
+
+            - name: jmeter-worker
+              image: justb4/jmeter
+              args: [ 
+                '-n',
+                '-t',
+                './FrontEnd.jmx',
+                '-l',
+                'summary.csv',
+                '-e',
+                '-o',
+                'test_report'
+              ]
+              volumeMounts:
+                - mountPath: "/config_data"
+                  name: chaos-eng-config
+              workingDir: "/config_data"
+

--- a/chaos/network-abort-100.yaml
+++ b/chaos/network-abort-100.yaml
@@ -1,0 +1,70 @@
+version: 1.0.0
+title: What happens if we abort responses
+description: If responses are aborted, the dependant application should retry and/or timeout requests
+tags:
+- k8s
+- istio
+- http
+configuration:
+  ingress_host:
+      type: env
+      key: INGRESS_HOST
+steady-state-hypothesis:
+  title: The app is healthy
+  probes:
+  - type: probe
+    name: app-responds-to-requests
+    tolerance: 200
+    provider:
+      type: http
+      timeout: 5
+      verify_tls: false
+      url: http://${ingress_host}?addr=http://front-end
+      headers:
+        Host: repeater.acme.com
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+method:
+- type: action
+  name: abort-failure
+  provider:
+    type: python
+    module: chaosistio.fault.actions
+    func: add_abort_fault
+    arguments:
+      virtual_service_name: front-end
+      http_status: 500
+      routes:
+        - destination:
+            host: front-end
+            subset: primary
+      percentage: 100
+      version: networking.istio.io/v1alpha3
+      ns: sock-shop
+  pauses: 
+    after: 1
+rollbacks:
+- type: action
+  name: remove-abort-failure
+  provider:
+    type: python
+    func: remove_abort_fault
+    module: chaosistio.fault.actions
+    arguments:
+      virtual_service_name: front-end
+      routes:
+        - destination:
+            host: front-end
+            subset: primary
+      version: networking.istio.io/v1alpha3
+      ns: sock-shop

--- a/chaos/network-delay.yaml
+++ b/chaos/network-delay.yaml
@@ -1,0 +1,100 @@
+version: 1.0.0
+title: What happens if we abort and delay responses
+description: If responses are aborted and delayed, the dependant application should retry and/or timeout requests
+tags:
+- k8s
+- istio
+- http
+configuration:
+  ingress_host:
+      type: env
+      key: INGRESS_HOST
+steady-state-hypothesis:
+  title: The app is healthy
+  probes:
+  - type: probe
+    name: app-responds-to-requests
+    tolerance: 200
+    provider:
+      type: http
+      timeout: 15
+      verify_tls: false
+      url: http://${ingress_host}?addr=http://front-end
+      headers:
+        Host: repeater.acme.com
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+method:
+- type: action
+  name: abort-failure
+  provider:
+    type: python
+    module: chaosistio.fault.actions
+    func: add_abort_fault
+    arguments:
+      virtual_service_name: front-end
+      http_status: 500
+      routes:
+        - destination:
+            host: front-end
+            subset: primary
+      percentage: 50
+      version: networking.istio.io/v1alpha3
+      ns: sock-shop
+- type: action
+  name: delay
+  provider:
+    type: python
+    module: chaosistio.fault.actions
+    func: add_delay_fault
+    arguments:
+      virtual_service_name: front-end
+      fixed_delay: 15s
+      routes:
+        - destination:
+            host: front-end
+            subset: primary
+      percentage: 50
+      version: networking.istio.io/v1alpha3
+      ns: sock-shop
+  pauses: 
+    after: 1
+rollbacks:
+- type: action
+  name: remove-abort-failure
+  provider:
+    type: python
+    func: remove_abort_fault
+    module: chaosistio.fault.actions
+    arguments:
+      virtual_service_name: front-end
+      routes:
+        - destination:
+            host: front-end
+            subset: primary
+      version: networking.istio.io/v1alpha3
+      ns: sock-shop
+- type: action
+  name: remove-delay
+  provider:
+    type: python
+    func: remove_delay_fault
+    module: chaosistio.fault.actions
+    arguments:
+      virtual_service_name: front-end
+      routes:
+        - destination:
+            host: front-end
+            subset: primary
+      version: networking.istio.io/v1alpha3
+      ns: sock-shop

--- a/chaos/network-dos.yaml
+++ b/chaos/network-dos.yaml
@@ -1,0 +1,48 @@
+version: 1.0.0
+title: What happens if we abort responses
+description: If responses are aborted, the dependant application should retry and/or timeout requests
+tags:
+- k8s
+- pod
+- deployment
+- istio
+configuration:
+  ingress_host:
+      type: env
+      key: INGRESS_HOST
+steady-state-hypothesis:
+  title: The app is healthy
+  probes:
+  - type: probe
+    name: app-responds-to-requests
+    tolerance: 200
+    provider:
+      type: http
+      timeout: 5
+      verify_tls: false
+      url: http://${ingress_host}?addr=http://sock-shop/limiter
+      headers:
+        Host: repeater.acme.com
+method:
+- type: action
+  name: abort-failure
+  provider:
+    type: process
+    path: kubectl
+    arguments:
+    - run
+    - siege
+    - --namespace
+    - sock-shop
+    - --image
+    - yokogawa/siege
+    - -it
+    - --rm
+    - -- 
+    - --concurrent
+    - 50
+    - --time
+    - 20S
+    - "http://sock-shop"
+  pauses: 
+    after: 5

--- a/chaos/network-rollback.yaml
+++ b/chaos/network-rollback.yaml
@@ -1,0 +1,70 @@
+version: 1.0.0
+title: What happens if we abort responses
+description: If responses are aborted, the dependant application should retry and/or timeout requests
+tags:
+- k8s
+- istio
+- http
+configuration:
+  ingress_host:
+      type: env
+      key: INGRESS_HOST
+steady-state-hypothesis:
+  title: The app is healthy
+  probes:
+  - type: probe
+    name: app-responds-to-requests
+    tolerance: 200
+    provider:
+      type: http
+      timeout: 5
+      verify_tls: false
+      url: http://${ingress_host}?addr=http://front-end
+      headers:
+        Host: repeater.acme.com
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+method:
+- type: action
+  name: abort-failure
+  provider:
+    type: python
+    module: chaosistio.fault.actions
+    func: add_abort_fault
+    arguments:
+      virtual_service_name: front-end
+      http_status: 500
+      routes:
+        - destination:
+            host: front-end
+            subset: primary
+      percentage: 50
+      version: networking.istio.io/v1alpha3
+      ns: sock-shop
+  pauses: 
+    after: 1
+rollbacks:
+- type: action
+  name: remove-abort-failure
+  provider:
+    type: python
+    func: remove_abort_fault
+    module: chaosistio.fault.actions
+    arguments:
+      virtual_service_name: front-end
+      routes:
+        - destination:
+            host: front-end
+            subset: primary
+      version: networking.istio.io/v1alpha3
+      ns: sock-shop

--- a/chaos/network.yaml
+++ b/chaos/network.yaml
@@ -1,0 +1,55 @@
+version: 1.0.0
+title: What happens if we abort responses
+description: If responses are aborted, the dependant application should retry and/or timeout requests
+tags:
+- k8s
+- istio
+- http
+configuration:
+  ingress_host:
+      type: env
+      key: INGRESS_HOST
+steady-state-hypothesis:
+  title: The app is healthy
+  probes:
+  - type: probe
+    name: app-responds-to-requests
+    tolerance: 200
+    provider:
+      type: http
+      timeout: 5
+      verify_tls: false
+      url: http://${ingress_host}?addr=http://front-end
+      headers:
+        Host: repeater.acme.com
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+  - type: probe
+    tolerance: 200
+    ref: app-responds-to-requests
+method:
+- type: action
+  name: abort-failure
+  provider:
+    type: python
+    module: chaosistio.fault.actions
+    func: add_abort_fault
+    arguments:
+      virtual_service_name: front-end
+      http_status: 500
+      routes:
+        - destination:
+            host: front-end
+            subset: primary
+      percentage: 50
+      version: networking.istio.io/v1alpha3
+      ns: sock-shop
+  pauses: 
+    after: 1

--- a/chaos/node-uncordon.yaml
+++ b/chaos/node-uncordon.yaml
@@ -34,7 +34,7 @@ method:
       pod_namespace: front-end
       delete_pods_with_local_storage: true
   pauses: 
-    after: 1
+    after: 50
 rollbacks:
 - type: action
   name: uncordon-node

--- a/chaos/once.yaml
+++ b/chaos/once.yaml
@@ -1,0 +1,43 @@
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: front-end-chaos
+  namespace: sock-shop
+spec:
+  activeDeadlineSeconds: 600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: front-end
+
+    spec:
+      serviceAccountName: chaostoolkit
+      restartPolicy: Never
+      containers:
+      - name: chaostoolkit
+        image: vfarcic/chaostoolkit:1.4.1-2
+        args:
+        - --verbose
+        - run
+        - /experiment/health-http.yaml
+        env:
+        - name: CHAOSTOOLKIT_IN_POD
+          value: "true"
+        volumeMounts:
+        - name: config
+          mountPath: /experiment
+          readOnly: true
+        resources:
+          limits:
+            cpu: 20m
+            memory: 64Mi
+          requests:
+            cpu: 20m
+            memory: 64Mi
+      volumes:
+      - name: config
+        configMap:
+          name: chaostoolkit-experiments

--- a/chaos/terminate-pod-pause.yaml
+++ b/chaos/terminate-pod-pause.yaml
@@ -1,6 +1,6 @@
 version: 1.0.0
 title: What happens if we terminate a Pod?
-description: If a Pod is terminated, a new one should be created in its places.
+description: If a Pod is terminated, the service should response the requests
 tags:
 - k8s
 - pod
@@ -26,7 +26,7 @@ method:
     func: terminate_pods
     arguments:
       label_selector: name=front-end
-      rand: true
+      rand: false
       ns: sock-shop
   pauses: 
     after: 50

--- a/chaos/terminate-pod-phase.yaml
+++ b/chaos/terminate-pod-phase.yaml
@@ -53,4 +53,4 @@ method:
       rand: true
       ns: sock-shop
   pauses: 
-    after: 10
+    after: 50

--- a/k8s/auth-aws.yml
+++ b/k8s/auth-aws.yml
@@ -1,0 +1,32 @@
+apiVersion: v1
+data:
+  mapRoles: |
+    - groups:
+      - system:bootstrappers
+      - system:nodes
+      rolearn: arn:aws:iam::961518039473:role/eksctl-chaos-engineering-cluster-NodeInstanceRole-749YEQ28JX5G
+      username: system:node:{{EC2PrivateDNSName}}
+  mapUsers: |
+    - userarn: arn:aws:iam::961518039473:user/juan.ocampor
+      username: juan.ocampor
+      groups:
+        - system:masters
+    - userarn: arn:aws:iam::961518039473:user/alejandro.ochoam
+      username: alejandro.ochoam
+      groups:
+        - system:masters
+    - userarn: arn:aws:iam::961518039473:user/alejandro.perdomo
+      username: alejandro.perdomo
+      groups:
+        - system:masters
+    - userarn: arn:aws:iam::961518039473:user/cristian.martinez
+      username: cristian.martinez
+      groups:
+        - system:masters
+kind: ConfigMap
+metadata:
+  creationTimestamp: "2021-09-15T15:31:56Z"
+  name: aws-auth
+  namespace: kube-system
+  resourceVersion: "47322"
+  uid: 949872b9-9154-4991-83b8-c80caadfd263

--- a/k8s/jmeter-frontend-cronjob.yaml
+++ b/k8s/jmeter-frontend-cronjob.yaml
@@ -1,0 +1,69 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: jmeter-frontend-cronjob
+  namespace: sock-shop
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            name: jmeter-fronted-cronjob
+        spec:
+          serviceAccountName: chaos-eng-svc-acct-s3
+          restartPolicy: Never
+
+          volumes:
+            - name: chaos-eng-config
+              emptyDir: {}
+
+          containers:
+            - name: s3-uploader
+              image: amazon/aws-cli:latest
+              imagePullPolicy: IfNotPresent
+              command: [
+                'bash',
+                '-c',
+                'sleep 2; aws s3api put-object --bucket chaos-engineering-config-files --key csv/$(date "+%Y%m%d-%H%M%s")-frontend.csv --body /config_data/summary.csv'
+              ]
+              volumeMounts:
+                - name: chaos-eng-config
+                  mountPath: "/config_data"
+
+          initContainers:
+            - name: s3-downloader
+              image: amazon/aws-cli:latest
+              imagePullPolicy: IfNotPresent
+              args: [
+                "s3api",
+                "get-object",
+                "--bucket",
+                "chaos-engineering-config-files",
+                "--key",
+                "FrontEnd.jmx",
+                "/config_data/FrontEnd.jmx"
+              ]
+              volumeMounts:
+                - name: chaos-eng-config
+                  mountPath: "/config_data"
+
+            - name: jmeter-worker
+              image: justb4/jmeter
+              imagePullPolicy: IfNotPresent
+              args: [ 
+                '-n',
+                '-t',
+                './FrontEnd.jmx',
+                '-l',
+                'summary.csv',
+                '-e',
+                '-o',
+                'test_report'
+              ]
+              volumeMounts:
+                - mountPath: "/config_data"
+                  name: chaos-eng-config
+              workingDir: "/config_data"
+


### PR DESCRIPTION
- Completed README.md with commands and steps for de examples of ChaosToolKit (CTK) for node experiments.

- Added CTK files in /chaos folder for examples of drain and uncordon Node.

- improvement for network test and jmeter cronJob